### PR TITLE
Adding addon versioning to standards [closes #123]

### DIFF
--- a/ember.md
+++ b/ember.md
@@ -17,6 +17,8 @@
 	[ [ Overall Application Errors](#errorHandling--overallApplication) ]
 1. **[Testing](#testing)**
 1. **[Definition of Ready](#deployment-checklist)**
+1. **[Addons](#addons)**
+  [ [Versioning](#versioning) ]
 
 <a name="general-structure"></a>
 ## General Structure
@@ -425,3 +427,20 @@ Create a build definition for the app that will:
 
 ### 11. Checklist Violations
 `npm test` (in the build definition) will catch errors and reject build
+
+
+
+<a name="addons"></a>
+## Addons
+
+<a name="versioning"></a>
+### 9.1 Versioning
+
+1. We define `1.0.0` release as the first version ready to be used by the end user. It may not be feature complete or bug free, but it should bring some benefit to our customers. As soon as the package is ready to be used in production, it needs to be on version `1.0.0`.
+
+1. **Major** update should be any type of update that will break/change the way the addon is used. It could be an HTML structural update, a JS update, or a CSS change, that requires the end user to update the way the addon is used.
+
+1. **Minor** update should be an update that introduces a new feature and does not have any impact on how the addon is used.
+
+1. **Patch** update should be any type of bug fix that does not have any impact on how the addon is used.
+

--- a/ember.md
+++ b/ember.md
@@ -439,8 +439,8 @@ Create a build definition for the app that will:
 We follow [Semantic Versioning](https://semver.org/) standards for versioning our addons:
 1. **Major** version should be used when making incompatible API changes.
 
-1. **Minor** version should be used when adding new functionality in a backwards-compatible manner.
-> Note: When updating `ember-cli` version use **minor** update.
+1. **Minor** version should be used when adding new functionality in a backward compatible manner.
+> Note: When updating `ember-cli` , use **minor** update.
 
-1. **Patch** version should be used when making backwards-compatible bug fixes, documentation updates, small enhancements (e.g., performance) that do not add new feature, or dependency updates.
+1. **Patch** version should be used when making backward compatible bug fixes, documentation updates, small enhancements (e.g., performance) that do not add new feature, or dependency updates.
 

--- a/ember.md
+++ b/ember.md
@@ -430,17 +430,17 @@ Create a build definition for the app that will:
 
 
 
-<a name="addons"></a>
 ## Addons
 
-<a name="versioning"></a>
 ### 9.1 Versioning
 
-1. We define `1.0.0` release as the first version ready to be used by the end user. It may not be feature complete or bug free, but it should bring some benefit to our customers. As soon as the package is ready to be used in production, it needs to be on version `1.0.0`.
+1. We define `1.0.0` release as the first version ready to be used by the end user. It may not be feature complete, but it should bring some benefit to our customers. `1.0.0` release should include tests and be bug free according to the developer. As soon as the package is ready to be used in production, it needs to be on version `1.0.0`.
 
-1. **Major** update should be any type of update that will break/change the way the addon is used. It could be an HTML structural update, a JS update, or a CSS change, that requires the end user to update the way the addon is used.
+We follow [Semantic Versioning](https://semver.org/) standards for versioning our addons:
+1. **Major** version should be used when making incompatible API changes.
 
-1. **Minor** update should be an update that introduces a new feature and does not have any impact on how the addon is used.
+1. **Minor** version should be used when adding new functionality in a backwards-compatible manner.
+> Note: When updating `ember-cli` version use **minor** update.
 
-1. **Patch** update should be any type of bug fix that does not have any impact on how the addon is used.
+1. **Patch** version should be used when making backwards-compatible bug fixes, documentation updates, small enhancements (e.g., performance) that do not add new feature, or dependency updates.
 


### PR DESCRIPTION
Do we want to use in-repo addons for pre-production development?