### PR TITLE
add standard for browser support specification for ember projects [closes #191]

### DIFF
--- a/General.md
+++ b/General.md
@@ -26,7 +26,7 @@ class Rectangle { //ES6 and Ember classes still use UpperCamelCase by general co
 
 ## Formatiing
 > Why? All of our code should be formatted so that it is clean, concise, and easily readable by any developer on the team
-* For properties, put a space after the semicolon (`:`)
+* For properties, put a space after the semicolon (`;`)
 
 **Bad**
 ```css

--- a/ember.md
+++ b/ember.md
@@ -753,7 +753,24 @@ Test the app in every browser that we support.
 
 If Mirage is being used, and the real API is available, test with both sets of data in each browser.  
 
-*Current Supported Browsers: ie11, firefox, safari (desktop and mobile), and chrome*
+*Current Supported Browsers: ie11, edge, firefox, safari, and chrome*
+
+This is what your `targets.js` file should look like within your ember project: 
+```js
+'use strict';
+
+const browsers = [
+    'ie 11',
+    'last 2 edge versions',
+    'last 2 Chrome versions',
+    'last 2 Firefox versions',
+    'last 2 Safari versions'
+];
+
+module.exports = {
+    browsers
+};
+```
 
 ### 10. Build Pipelines Defined
 Configure **stg.ashui** build with Mirage data  


### PR DESCRIPTION
I also got rid of the parenthesis for safari stating (mobile and desktop) as that felt redundant since the same is true for the other browsers